### PR TITLE
Disable calling handleModels() if there are no models set

### DIFF
--- a/service.js
+++ b/service.js
@@ -93,7 +93,9 @@ function register (angular) {
     }
     function setOptions (scope, name, options) {
       var bag = add(scope, name, dragula(options));
-      handleModels(scope, bag.drake);
+      if(bag.drake.models){
+        handleModels(scope, bag.drake);
+      }
     }
   }];
 }


### PR DESCRIPTION
This prevents a TypeError from happening when trying to find a sourceModel on an undefined drake.models object when no dragula-model has been set but setOptions() gets called because of the need to set/override options on the drake instance.

If I don't set an `dragula-model` in my attributes

    <div class="item-container" dragula="'items'">...</div>

And then try to modify any properties of the `drake`

    dragulaService.options($scope, 'items', {
      // yada yada
    });

`handleModels()` gets called inside `setOptions()`, but the `drake.models` is `undefined`, thus the line `33`

    sourceModel = drake.models[drake.containers.indexOf(source)];

yields a `TypeError`