### PR TITLE
Fix model watcher

### DIFF
--- a/directive.js
+++ b/directive.js
@@ -31,14 +31,20 @@ function register (angular) {
         dragulaService.add(dragulaScope, name, drake);
       }
 
-      scope.$watch('dragulaModel', function(newValue, oldValue) {
-        if(newValue){
-          if(drake.models){
-            var modelIndex = drake.models.indexOf(oldValue);
+      scope.$watch('dragulaModel', function (newValue, oldValue) {
+        if (!newValue || newValue === oldValue) {
+          return;
+        }
+
+        if (drake.models) {
+          var modelIndex = oldValue ? drake.models.indexOf(oldValue) : -1;
+          if (modelIndex >= 0) {
             drake.models.splice(modelIndex, 1, newValue);
-          }else{
-            drake.models = [newValue];
+          } else {
+            drake.models.push(newValue);
           }
+        } else {
+          drake.models = [newValue];
         }
       });
     }


### PR DESCRIPTION
After upgrading to `v1.1.9` I started getting an error when moving items:

`TypeError: Cannot read property 'splice' of undefined` at `applyDrop` ([service.js:42](https://github.com/bevacqua/angular-dragula/blob/master/service.js#L42))

This only occurs when there are multiple instances of the directive using the same bag, but with different `dragulaModel` values, such as when using a nested ng-repeat. 

After some investigation I found this was due to a bug in the `$watch` expression (introduced in `v1.1.7` by #35) which was basically not checking if the model was actually in the array before calling `splice`; causing the last model in the array to be replaced every time. This PR checks for that and calls `push` instead when the model isn't found.