### PR TITLE
Update Handle

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -48,7 +48,7 @@ app.controller('MuchExampleCtrl', ['$scope', 'dragulaService',
   function ($scope, dragulaService) {
     dragulaService.options($scope, 'sixth-bag', {
       moves: function (el, container, handle) {
-        return handle.className === 'handle';
+        return handle.classList.contains('handle');
       }
     });
   }


### PR DESCRIPTION
In reality we usually may use other classes with 'handle' classes. So it is better to compare with contains than equal.